### PR TITLE
adds driver function to smoothly stop data transmission while MessagePack mode

### DIFF
--- a/ads129x_client/hackeeg/driver.py
+++ b/ads129x_client/hackeeg/driver.py
@@ -304,6 +304,17 @@ class HackEEGBoard:
         self.rdatac_mode = False
         return result
 
+    def stop_and_sdatac_messagepack(self):
+        """used to smoothly stop data transmission while in MessagePack mode–
+        mostly avoids exceptions and other hiccups"""
+        self.send_command("stop")
+        self.send_command("sdatac")
+        self.send_command("nop")
+        try:
+            line = self.serial_port.read()
+        except UnicodeDecodeError:
+            line = self.raw_serial_port.read()
+
     def enable_channel(self, channel, gain=None):
         if gain is None:
             gain = ads1299.GAIN_1X

--- a/ads129x_client/hackeeg_test.py
+++ b/ads129x_client/hackeeg_test.py
@@ -107,14 +107,7 @@ class HackEegTestApplication:
                 print("no data to decode")
                 print(f"result: {result}")
         duration = end_time - start_time
-        self.hackeeg.send_command("stop")
-        self.hackeeg.send_command("sdatac")
-        self.hackeeg.send_command("nop")
-        try:
-            line = self.hackeeg.serial_port.read()
-        except UnicodeDecodeError:
-            line = self.hackeeg.raw_serial_port.read()
-
+        self.hackeeg.stop_and_sdatac_messagepack()
         self.hackeeg.blink_board_led()
         print(f"duration in seconds: {duration}")
         samples_per_second = max_samples / duration


### PR DESCRIPTION
adds driver function to smoothly stop data transmission while MessagePack mode:

- mostly avoids exceptions and other hiccups
- refactor, moved from hackeeg_test.py