### PR TITLE
add sample numbers to rdatac responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,7 +228,6 @@ In MessagePack mode, status text is omitted.
 
 #### Software library
 
-
 The Arduino driver uses the [ArduinoJson](https://arduinojson.org/) library for encoding and decoding MessagePack data, except for `rdata` and `rdatac` messages– those use a custom, optimized sending routine.
 
 
@@ -236,37 +235,44 @@ The Arduino driver uses the [ArduinoJson](https://arduinojson.org/) library for 
 
 The packed byte-array used for `rdata` and `rdatac` transfers has this format:
 
-| position | function  | byte |
-|----------|-----------|------|
-| 00       | timestamp |    0 |
-| 01       | timestamp |    1 |
-| 02       | timestamp |    2 |
-| 03       | timestamp |    3 |
-| 04       | channel 1 |    0 |
-| 05       | channel 1 |    1 |
-| 06       | channel 1 |    2 |
-| 07       | channel 2 |    0 |
-| 08       | channel 2 |    1 |
-| 09       | channel 2 |    2 |
-| 10       | channel 3 |    0 |
-| 11       | channel 3 |    1 |
-| 12       | channel 3 |    2 |
-| 13       | channel 4 |    0 |
-| 14       | channel 4 |    1 |
-| 15       | channel 4 |    2 |
-| 16       | channel 5 |    0 |
-| 17       | channel 5 |    1 |
-| 18       | channel 5 |    2 |
-| 19       | channel 6 |    0 |
-| 20       | channel 6 |    1 |
-| 21       | channel 6 |    2 |
-| 22       | channel 7 |    0 |
-| 23       | channel 7 |    1 |
-| 24       | channel 7 |    2 |
-| 25       | channel 8 |    0 |
-| 26       | channel 8 |    1 |
-| 27       | channel 8 |    2 |
+| position | function      | byte |
+|----------|---------------|------|
+| 00       | timestamp     |    0 |
+| 01       | timestamp     |    1 |
+| 02       | timestamp     |    2 |
+| 03       | timestamp     |    3 |
+| 04       | sample number |    0 |
+| 05       | sample number |    1 |
+| 06       | sample number |    2 |
+| 07       | sample number |    3 |
+| 08       | channel 1     |    0 |
+| 09       | channel 1     |    1 |
+| 10       | channel 1     |    2 |
+| 11       | channel 2     |    0 |
+| 12       | channel 2     |    1 |
+| 13       | channel 2     |    2 |
+| 14       | channel 3     |    0 |
+| 15       | channel 3     |    1 |
+| 16       | channel 3     |    2 |
+| 17       | channel 4     |    0 |
+| 18       | channel 4     |    1 |
+| 19       | channel 4     |    2 |
+| 20       | channel 5     |    0 |
+| 21       | channel 5     |    1 |
+| 22       | channel 5     |    2 |
+| 23       | channel 6     |    0 |
+| 24       | channel 6     |    1 |
+| 25       | channel 6     |    2 |
+| 26       | channel 7     |    0 |
+| 27       | channel 7     |    1 |
+| 28       | channel 7     |    2 |
+| 29       | channel 8     |    0 |
+| 30       | channel 8     |    1 |
+| 31       | channel 8     |    2 |
 
+* `timestamp` is an unsigned long, the result of calling the Arduino's `micros()` function right before the sample is taken.
+* `sample number` is an unsigned long, the value is incremented for every sample received by the driver. It is reset every time you issue the `start` command. You can analyze the sample number sequence on the client to see if your client code is dropping or missing samples.
+* For an example Python decoding function, see [`_decode_data()`](https://github.com/adamfeuer/ADS129x-tools/blob/master/ads129x_client/hackeeg/driver.py#L123-L152) in the file `hackeeg/driver.py`.
 
 
 ## Python Client Software

--- a/ads129x_client/hackeeg/driver.py
+++ b/ads129x_client/hackeeg/driver.py
@@ -135,7 +135,8 @@ class HackEEGBoard:
                         print(f"incorrect padding: {data}")
             if data and (type(data) is list or type(data) is bytes):
                 timestamp = int.from_bytes(data[0:4], byteorder='little')
-                ads_status = int.from_bytes(data[4:7], byteorder='big')
+                sample_number = int.from_bytes(data[4:8], byteorder='little')
+                ads_status = int.from_bytes(data[8:11], byteorder='big')
                 ads_gpio = ads_status & 0x0f
                 loff_statn = (ads_status >> 4) & 0xff
                 loff_statp = (ads_status >> 12) & 0xff
@@ -143,7 +144,7 @@ class HackEEGBoard:
 
                 channel_data = []
                 for channel in range(0, 8):
-                    channel_offset = 7 + (channel * 3)
+                    channel_offset = 11 + (channel * 3)
                     sample = int.from_bytes(data[channel_offset:channel_offset + 3], byteorder='little')
                     channel_data.append(sample)
 

--- a/ads129x_client/hackeeg/driver.py
+++ b/ads129x_client/hackeeg/driver.py
@@ -148,7 +148,7 @@ class HackEEGBoard:
                     sample = int.from_bytes(data[channel_offset:channel_offset + 3], byteorder='little')
                     channel_data.append(sample)
 
-                decoded_data = dict(timestamp=timestamp, ads_status=ads_status, ads_gpio=ads_gpio, loff_statn=loff_statn, loff_statp=loff_statp, extra=extra, channel_data=channel_data)
+                decoded_data = dict(timestamp=timestamp, sample_number=sample_number, ads_status=ads_status, ads_gpio=ads_gpio, loff_statn=loff_statn, loff_statp=loff_statp, extra=extra, channel_data=channel_data)
                 response[self.DecodedDataKey] = decoded_data
         return response
 

--- a/ads129x_client/hackeeg_test.py
+++ b/ads129x_client/hackeeg_test.py
@@ -28,7 +28,8 @@ class HackEegTestApplication:
         if samples_per_second not in SPEEDS.keys():
             raise HackEegTestApplicationException("{} is not a valid speed; valid speeds are {}".format(
                 samples_per_second, sorted(SPEEDS.keys())))
-        self.hackeeg.jsonlines_mode()
+        self.hackeeg.stop_and_sdatac_messagepack()
+        # self.hackeeg.jsonlines_mode()
         self.hackeeg.sdatac()
         self.hackeeg.reset()
         self.hackeeg.blink_board_led()
@@ -39,15 +40,17 @@ class HackEegTestApplication:
         test_signal_mode = ads1299.INT_TEST_4HZ | ads1299.CONFIG2_const
         self.hackeeg.wreg(ads1299.CONFIG2, test_signal_mode)
 
-        for channel in range(1, 9):
-            self.hackeeg.enable_channel(channel)
-            self.hackeeg.wreg(ads1299.CHnSET + channel, ads1299.ELECTRODE_INPUT | ads1299.GAIN_1X)
+        self.hackeeg.disable_all_channels()
+        # for channel in range(1, 9):
+        # for channel in range(7, 7):
+        #     self.hackeeg.enable_channel(channel)
+        #     self.hackeeg.wreg(ads1299.CHnSET + channel, ads1299.TEST_SIGNAL | ads1299.GAIN_1X)
 
         # Unipolar mode - setting SRB1 bit sends mid-supply voltage to the N inputs
         self.hackeeg.wreg(ads1299.MISC1, ads1299.SRB1)
         # add channels into bias generation
         self.hackeeg.wreg(ads1299.BIAS_SENSP, ads1299.BIAS8P)
-        self.hackeeg.messagepack_mode()
+        # self.hackeeg.messagepack_mode()
         self.hackeeg.start()
         self.hackeeg.rdatac()
         return

--- a/ads129x_client/hackeeg_test.py
+++ b/ads129x_client/hackeeg_test.py
@@ -40,17 +40,19 @@ class HackEegTestApplication:
         test_signal_mode = ads1299.INT_TEST_4HZ | ads1299.CONFIG2_const
         self.hackeeg.wreg(ads1299.CONFIG2, test_signal_mode)
 
+        # one channel enabled
         self.hackeeg.disable_all_channels()
+        self.hackeeg.wreg(ads1299.CHnSET + 7, ads1299.TEST_SIGNAL | ads1299.GAIN_2X)
+
+        # all channels enabled
         # for channel in range(1, 9):
-        # for channel in range(7, 7):
-        #     self.hackeeg.enable_channel(channel)
-        #     self.hackeeg.wreg(ads1299.CHnSET + channel, ads1299.TEST_SIGNAL | ads1299.GAIN_1X)
+        #     self.hackeeg.wreg(ads1299.CHnSET + channel, ads1299.TEST_SIGNAL | ads1299.GAIN_2X)
 
         # Unipolar mode - setting SRB1 bit sends mid-supply voltage to the N inputs
         self.hackeeg.wreg(ads1299.MISC1, ads1299.SRB1)
         # add channels into bias generation
         self.hackeeg.wreg(ads1299.BIAS_SENSP, ads1299.BIAS8P)
-        # self.hackeeg.messagepack_mode()
+        self.hackeeg.messagepack_mode()
         self.hackeeg.start()
         self.hackeeg.rdatac()
         return
@@ -93,12 +95,13 @@ class HackEegTestApplication:
                     decoded_data = result.get(self.hackeeg.DecodedDataKey)
                     if decoded_data:
                         timestamp = decoded_data.get('timestamp')
+                        sample_number = decoded_data.get('sample_number')
                         ads_gpio = decoded_data.get('ads_gpio')
                         loff_statp = decoded_data.get('loff_statp')
                         loff_statn = decoded_data.get('loff_statn')
                         channel_data = decoded_data.get('channel_data')
                         if not self.quiet:
-                            print(f"timestamp:{timestamp} | gpio:{ads_gpio} loff_statp:{loff_statp} loff_statn:{loff_statn}   ",
+                            print(f"timestamp:{timestamp} sample_number: {sample_number}| gpio:{ads_gpio} loff_statp:{loff_statp} loff_statn:{loff_statn}   ",
                                   end='')
                             for channel_number, sample in enumerate(channel_data):
                                 print(f"{channel_number+1}:{sample} ", end='')

--- a/ads129x_driver/ads129x_driver.ino
+++ b/ads129x_driver/ads129x_driver.ino
@@ -29,10 +29,9 @@
 #include "Base64.h"
 #include "SpiDma.h"
 
-//#define BAUD_RATE  115200     // WiredSerial ignores this and uses the maximum rate
-#define BAUD_RATE 2000000
-#define txActiveChannelsOnly  // reduce bandwidth: only send data for active data channels
-#define WiredSerial SerialUSB // use Due's Native USB port
+
+#define BAUD_RATE 2000000     // WiredSerial ignores this and uses the maximum rate
+#define WiredSerial SerialUSB // use the Arduino Due's Native USB port
 
 #define SPI_BUFFER_SIZE 200
 #define OUTPUT_BUFFER_SIZE 1000
@@ -588,14 +587,6 @@ void detectActiveChannels() {  //set device into RDATAC (continous) mode -it wil
         if ((chSet & 7) != SHORTED) num_active_channels++;
     }
 }
-
-//#define testSignal //use this to determine if your software is accurately measuring full range 24-bit signed data -8388608..8388607
-#ifdef testSignal
-int testInc = 1;
-int testPeriod = 100;
-byte testMSB, testLSB;
-#endif
-
 
 inline void send_samples(void) {
     if ((!is_rdatac) || (num_active_channels < 1)) return;


### PR DESCRIPTION
### Summary

* adds a sample number to each rdatac sample response
* in addition to timestamp
* does not impact transmission speed
* cpp driver and python client code are updated to use it
* can be used to see if client code is dropping samples – sample code in `hackeeg_test.py` shows how to use it.
* documentation is updated

### Impact

* changes data byte-array decoding in an incompatible way

### Limitations / TODO

* none

### Testing

* `hackeeg_test.py` is updated to use the sample number to check for dropped samples.

